### PR TITLE
[Feat/utils] Add validation functions for assertions

### DIFF
--- a/tagupy/design/generator/_fullfact.py
+++ b/tagupy/design/generator/_fullfact.py
@@ -6,6 +6,7 @@ import numpy as np
 from typing import Iterable
 
 from tagupy.type import _Generator as Generator
+from tagupy.utils import is_positive_int, is_positive_int_list
 
 
 class FullFact(Generator):
@@ -40,11 +41,9 @@ class FullFact(Generator):
             (when n_rep = 1, it implies that a single run
             for each condition will be planed)
         '''
+        assert is_positive_int(n_rep), \
+            f"Invalid input: n_rep expected positive (>0) integer, got {type(n_rep)}::{n_rep}"
         self.n_rep = n_rep
-        assert isinstance(n_rep, int), \
-            f"Error: n_rep expected int, got: {type(n_rep)}"
-        assert n_rep >= 1, \
-            f"Error: n_rep expected integer >=1, got: {n_rep}"
 
     def get_exmatrix(self, levels: Iterable[int]) -> np.ndarray:
         '''
@@ -94,16 +93,10 @@ class FullFact(Generator):
                [1, 2, 0],
                [1, 2, 1]])
         '''
-        assert isinstance(levels, list), \
-            f'Error: dtype of levels expected List, got {type(levels)}'
-        for i in levels:
-            assert isinstance(i, int), \
-                f'Error: dtype of elements in the levels expected int,\
-                     got {type(i)}'
-            assert i >= 1, \
-                f'Error: elements in the levels expected integer >=1, got {i}'
+        assert is_positive_int_list(levels), \
+            f'Invalid input: levels is List of positive (>0) integer, got {type(levels)}::{levels}'
 
         ary = [np.arange(i, dtype=np.int8) for i in levels]
-        exmatrix = np.indices(levels).reshape(len(ary), -1).T
+        exmatrix = np.indices(list(levels)).reshape(len(ary), -1).T
 
         return np.vstack([exmatrix] * self.n_rep)

--- a/tagupy/design/generator/_onehot.py
+++ b/tagupy/design/generator/_onehot.py
@@ -5,6 +5,7 @@ _Generator Class of One Hot Design Generator Module
 import numpy as np
 
 from tagupy.type import _Generator as Generator
+from tagupy.utils import is_positive_int
 
 
 class OneHot(Generator):
@@ -51,11 +52,9 @@ class OneHot(Generator):
             (when n_rep = 1, it implies that a single run
             for each condition will be planed)
         """
+        assert is_positive_int(n_rep), \
+            f"Invalid input: n_rep expected positive (>0) integer, got {type(n_rep)}::{n_rep}"
         self.n_rep = n_rep
-        assert isinstance(n_rep, int), \
-            f"n_rep expected int, got {type(n_rep)}"
-        assert self.n_rep >= 1, \
-            f"n_rep expected integer >=1, got{n_rep}"
 
     def get_exmatrix(self, n_factor: int) -> np.ndarray:
         """
@@ -84,19 +83,9 @@ class OneHot(Generator):
                [1, 0],
                [0, 1],
                [0, 0]])
-        >>> # n_factor expects integer >=1
-        >>> model.get_exmatrix(n_factor="asdf")
-        Traceback (most recent call last):
-          ...
-        AssertionError: n_factor expected int, got <class 'str'>
-        >>> model.get_exmatrix(n_factor=0)
-        Traceback (most recent call last):
-          ...
-        AssertionError: n_factor expected integer >= 1, got 0
         """
-        assert isinstance(n_factor, int), \
-            f"n_factor expected int, got {type(n_factor)}"
-        assert n_factor >= 1, \
-            f"n_factor expected integer >= 1, got {n_factor}"
+        assert is_positive_int(n_factor), \
+            f"Invalid input: n_factor expected positive (>0) int, got {type(n_factor)}::{n_factor}"
+
         res = np.vstack([np.identity(n_factor, int), np.zeros(n_factor, int)] * self.n_rep)
         return res

--- a/tagupy/utils/__init__.py
+++ b/tagupy/utils/__init__.py
@@ -1,8 +1,8 @@
 from . import _functions
 from . import _validators
 
-from ._functions import *  # noqa: F401, F403
-from ._validators import * # noqa: F401, F403
+from ._functions import *   # noqa: F401, F403
+from ._validators import *  # noqa: F401, F403
 
 __all__ = []
 

--- a/tagupy/utils/__init__.py
+++ b/tagupy/utils/__init__.py
@@ -1,4 +1,10 @@
 from . import _functions
-from ._functions import *  # noqa: F401, F403
+from . import _validators
 
-__all__ = _functions.__all__.copy()
+from ._functions import *  # noqa: F401, F403
+from ._validators import * # noqa: F401, F403
+
+__all__ = []
+
+__all__.extend(_functions.__all__.copy())
+__all__.extend(_validators.__all__.copy())

--- a/tagupy/utils/_validators.py
+++ b/tagupy/utils/_validators.py
@@ -1,0 +1,79 @@
+"""
+Utility validators
+"""
+from typing import Any, Iterable, Iterable
+
+
+__all__ = [
+    "is_positive_int",
+    "is_positive_int_list",
+]
+
+
+def is_positive_int(arg: Any) -> bool:
+    """
+    Validate if the arg follows the correct form.
+
+    Parameters
+    ----------
+    arg: Any
+        arg is expected the following props.
+        1. Each element in arg, belongs to Integer, and is positive (>0).
+
+    Retrun
+    ------
+    result: Bool
+        Function returns True, if the arg following the expected props.
+        Otherwise, it returns False.
+
+    Examples
+    --------
+    >>> from tagupy.utils import is_positive_int
+    >>> is_positive_int(3)
+    True
+    >>> is_positive_int(0.5)
+    False
+    >>> is_positive_int(0)
+    False
+    """
+    return isinstance(arg, int) and arg > 0
+
+
+def is_positive_int_list(arg: Any) -> bool:
+    """
+    Validate if the arg follows the correct form.
+
+    Parameters
+    ----------
+    arg: Any
+        arg is expected the following props.
+        1. arg belongs to Iterable[int], being able to cast to List, and not empty
+        2. Each element in arg, belongs to Integer and is positive (>0).
+
+    Retrun
+    ------
+    result: Bool
+        Function returns True, if the arg following the expected props.
+        Otherwise, it returns False.
+
+    Examples
+    --------
+    >>> from tagupy.utils import is_positive_int_list
+    >>> is_positive_int_list([1, 2, 3])
+    True
+    >>> is_positive_int_list([1, 0.2, 3])
+    False
+    >>> is_positive_int_list([1, 2, 0])
+    False
+    >>> is_positive_int_list('string')
+    False
+    >>> is_positive_int_list([])
+    False
+    """
+    map(is_positive_int, arg)
+    is_list = isinstance(arg, Iterable) 
+    length = sum(1 for _ in arg)
+    is_empty = length > 0
+    is_pos_int = sum(map(is_positive_int, arg)) == length
+
+    return is_list and is_empty and is_pos_int

--- a/tagupy/utils/_validators.py
+++ b/tagupy/utils/_validators.py
@@ -1,7 +1,7 @@
 """
 Utility validators
 """
-from typing import Any, Iterable, Iterable
+from typing import Any, Iterable
 
 
 __all__ = [
@@ -71,7 +71,7 @@ def is_positive_int_list(arg: Any) -> bool:
     False
     """
     map(is_positive_int, arg)
-    is_list = isinstance(arg, Iterable) 
+    is_list = isinstance(arg, Iterable)
     length = sum(1 for _ in arg)
     is_empty = length > 0
     is_pos_int = sum(map(is_positive_int, arg)) == length

--- a/tests/design/generator/test_fullfact.py
+++ b/tests/design/generator/test_fullfact.py
@@ -21,22 +21,13 @@ def test_init_vaild_input():
 
 
 def test_init_invalid_input():
-    arg = [
-        ['a', 3.2, None, [2], np.zeros((2, 3)), np.inf, -np.inf],
-        [0, -1]
-    ]
+    arg = ['a', 3.2, None, [2], np.zeros((2, 3)), np.inf, -np.inf, 0, -1]
 
-    for i in arg[0]:
-        with pytest.raises(AssertionError) as e:
-            FullFact(i)
-        assert f'{type(i)}' in f"{e.value}", \
-            f'ERROR: Assertion msg should contain reasons, got "{e.value}"'
-
-    for i in arg[1]:
+    for i in arg:
         with pytest.raises(AssertionError) as e:
             FullFact(i)
         assert f'{i}' in f"{e.value}", \
-            'ERROR: Assertion msg should contain reasons, got "{e.value}"'
+            f"NoReasons: Inform the AssertionError reasons, got {e.value}"
 
 
 def test_init_valid_output():
@@ -77,22 +68,11 @@ def test_getexmatrix_invalid_input():
     model = FullFact(3)
 
     with pytest.raises(AssertionError) as e:
-        for i in arg[0]:
-            model.get_exmatrix(i)
-            assert f'{i}' in f"{e.value}",\
-                f'Error: Assertion msg should contain reasons, got {e.value}'
-
-        for i in arg[1]:
-            for j in i:
-                model.get_exmatrix(j)
-                assert f'{j}' in f"{e.value}",\
-                    f'Error: Assertion msg should contain reasons, got {e.value}'
-
-        for i in arg[2]:
-            for j in i:
-                model.get_exmatrix(j)
-                assert f'{j}' in f"{e.value}",\
-                    f'Error: Assertion msg should contain reasons, got {e.value}'
+        for idx in range(len(arg)):
+            for i in arg[idx]:
+                model.get_exmatrix(i)
+                assert f'{i}' in f"{e.value}",\
+                    f"NoReasons: Inform the AssertionError reasons, got {e.value}"
 
 
 def test_getexmatrix_invalid_output(correct_input):

--- a/tests/design/generator/test_onehot.py
+++ b/tests/design/generator/test_onehot.py
@@ -15,43 +15,32 @@ def correct_inputs():
 
 def test_init_invalid_input():
     arg = [
-        ["moge", None, np.ones((2, 3)), 3.4],
-        [0, -22]
+        ["moge", None, np.ones((2, 3)), 3.4, 0, -22]
     ]
-    for el in arg[0]:
+    for el in arg:
         with pytest.raises(AssertionError) as e:
             OneHot(el)
-        assert f"{type(el)}" in f"{e.value}", \
-            f"n_rep expected int, got {type(el)}"
-    for el in arg[1]:
-        with pytest.raises(AssertionError) as e:
-            OneHot(el)
-        assert f"n_rep expected >= 1, got {el}"
+        assert f"{el}" in f"{e.value}", \
+            f"NoReasons: Inform the AssertionError reasons, got {e.value}"
 
 
 def test_init_correct_input(correct_inputs):
     exp = [1, 2, 3, 4, 5, 6, 7]
     for i, el in enumerate(correct_inputs):
         assert OneHot(el).n_rep == exp[i], \
-            f"self.n_rep expected {exp[i]}, \
-                got {OneHot(el).n_rep}"
+            f"self.n_rep expected {exp[i]}, got {OneHot(el).n_rep}"
 
 
 def test_get_exmatrix_invalid_input_dtype():
     arg = [
-        ["moge", None, np.ones((2, 3)), 3.4],
-        [0, -1]
+        ["moge", None, np.ones((2, 3)), 3.4, 0, -1]
     ]
     model = OneHot(1)
-    for n_factor in arg[0]:
+    for n_factor in arg:
         with pytest.raises(AssertionError) as e:
             model.get_exmatrix(n_factor)
-        assert f"{type(n_factor)}" in f"{e.value}", \
-            f"n_rep expected int, got {type(n_factor)}"
-    for n_factor in arg[1]:
-        with pytest.raises(AssertionError) as e:
-            model.get_exmatrix(n_factor)
-        assert f"n_rep expected >= 1, got {n_factor}"
+        assert f"{n_factor}" in f"{e.value}", \
+            f"NoReasons: Inform the AssertionError reasons, got {e.value}"
 
 
 def test_get_exmatrix_output_dtype(correct_inputs):


### PR DESCRIPTION
* TaguPy version:
* Python version:
* Operating System:

## What
- Add the following validation functions
  - is_positive_int
  - is_positive_int_list
- Refactor current generators test with those functions

## Why
In the current code, the same assertion codes appear multiple times, and this is not good.