### PR TITLE
:tada: add multinomial simulator files

### DIFF
--- a/tagupy/simulator/__init__.py
+++ b/tagupy/simulator/__init__.py
@@ -1,1 +1,5 @@
-__all__ = []
+from ._multinomial import Multinomial
+
+__all__ = [
+    "Multinomial"
+]

--- a/tagupy/simulator/_multinomial.py
+++ b/tagupy/simulator/_multinomial.py
@@ -1,0 +1,43 @@
+import numpy as np
+from math import factorial
+
+from tagupy.type import _Simulator as Simulator
+
+def combinations(n, r):
+    return factorial(n) // (factorial(n - r) * factorial(r))
+
+class Multinomial(Simulator):
+    
+    def __init__(self, n_factor: int, n_out: int, max_dim: int):
+        assert type(n_factor)==int and n_factor>0, \
+        'type of n_factor must be a natural number or 0'
+        assert type(n_out)==int and n_out>0, \
+        'type of n_out must be a natural number or 0' 
+        assert type(max_dim)==int and max_dim>0, \
+        'type of max_dim must be a natural number or 0'
+        assert max_dim<=n_factor, \
+        'Expected max_dim is equal or smaller than n_factor : Got larger max_dim'
+        
+        self.n_factor = n_factor
+        self.n_out = n_out
+        self.max_dim = max_dim
+        
+        temp = 0
+        for i in range(max_dim):
+            temp += combinations(n_factor, i)
+        
+        self.coef_column = temp
+        self.coef_table = np.random.randn(n_out, self.coef_column)
+        # self.var_err = np.random. <- errorのvarianceはどうするか？変動係数を一定にするようにするとか
+                
+    def simulate(self, exmatrix: np.ndarray) -> np.ndarray:
+        
+        assert type(exmatrix) == np.ndarray,\
+        'AttributeError: The type of input matrix must be np.ndarray' 
+        assert exmatrix.shape[1]==self.coef_table.shape[1],\
+        f'ValueError: The dimention of exmatrix[1] must be n_factor, expect {self.coef_table.shape[1]}, got {exmatrix.shape[1]}'
+        
+        # err_mat = random.gauss()
+        resmatrix = exmatrix @ self.coef_table.T
+        
+        return resmatrix

--- a/tagupy/utils/_functions.py
+++ b/tagupy/utils/_functions.py
@@ -1,10 +1,15 @@
 """
 Utility functions
 """
+from itertools import combinations
+from typing import List
+
 import numpy as np
+
 
 __all__ = [
     "get_corr_matrix",
+    "get_comb_name",
 ]
 
 
@@ -49,3 +54,17 @@ def get_corr_matrix(exmatrix: np.ndarray, max_dim: int) -> np.ndarray:
         raise NotImplementedError('Support only max_dim = 1')
 
     return np.corrcoef(exmatrix.T)
+
+
+def get_comb_name(
+    factor_name: List[str],
+    max_dim: int,
+    operator: str = ''
+) -> List[str]:
+    '''
+    Get the combination string from string list
+    '''
+    _factor_multi_name = [list(combinations(factor_name, d)) for d in range(1, max_dim+1)]
+    factor_multi_name = sum(_factor_multi_name, [])
+
+    return [f'{operator}'.join(f) for f in factor_multi_name]

--- a/tagupy/utils/_validators.py
+++ b/tagupy/utils/_validators.py
@@ -36,7 +36,7 @@ def is_positive_int(arg: Any) -> bool:
     >>> is_positive_int(0)
     False
     """
-    return isinstance(arg, int) and arg > 0
+    return (type(arg) == int) and arg > 0
 
 
 def is_positive_int_list(arg: Any) -> bool:

--- a/tests/simulator/test_multinomial.py
+++ b/tests/simulator/test_multinomial.py
@@ -3,194 +3,185 @@ from math import factorial
 import pytest
 
 from tagupy.simulator import Multinomial
+from tagupy.utils import get_comb_name
 
-def combinations(n, r):
+
+def get_n_comb(n, r):
     return factorial(n) // (factorial(n - r) * factorial(r))
 
-@pytest.fixture
 
+@pytest.fixture
 def correct_input():
     return [1, 2, 3, 4, 5, 6, 30]
 
 
-# Red test: inappropriate inputs : n_factor
-def test_invalid_n_factor(): # 何のテストなのかわかりやすい関数名
+# Red test: inappropriate in
+def test_invalid_n_factor():
     arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2]]
     n_out = 2
     max_dim = 2
-    
+
     for v in arg:
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(ValueError) as e:
             Multinomial(v, n_out, max_dim)
-            assert f'{v}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+        assert f'{v}' in f'{e.value}', \
+            f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+
 
 # Green test
 def test_correct_n_factor(correct_input):
     n_out = 2
     max_dim = 2
-    
-    for i, v in enumerate(correct_input):
-        
-        temp = 0
-        for j in range(max_dim):
-            temp += combinations(v, j)
-        ref_col = temp
-        
-        assert Multinomial(v, n_out, max_dim).n_factor == v, \
-        f'self.n_factor expected {v}, got {Multinomial(v, n_out, max_dim).n_factor}'
-        
-        assert Multinomial(v, n_out, max_dim).coef_column == ref_col,\
-        f'shape of self.coef_table expected {n_out, ref_col}, got {Multinomial(v, n_out, max_dim).coef_table.shape[0], Multinomial(v, n_out, max_dim).coef_column}'
 
+    for v in correct_input[1:]:
+        ref_col = get_comb_name([f'x{i}' for i in range(v)], max_dim)
+        res = Multinomial(v, n_out, max_dim)
 
+        assert res.n_factor == v, \
+            f'self.n_factor expected {v}, got {res.n_factor}'
 
-# Red test: inappropriate inputs : n_factor
-def test_invalid_n_factor(): # 何のテストなのかわかりやすい関数名
-    arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2]]
-    n_out = 2
-    max_dim = 2
-    
-    for v in arg:
-        with pytest.raises(AssertionError) as e:
-            Multinomial(v, n_out, max_dim)
-            assert f'{v}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+        assert res.coef_column == ref_col,\
+            f'shape of self.coef_table expected {(n_out, ref_col)}, got {res.coef_table.shape}'
 
-# Green test
-def test_correct_n_factor(correct_input):
-    n_out = 2
-    max_dim = 2
-    ref_col = []
- 
-    for i, v in enumerate(correct_input):
-        
-        temp = 0
-        for j in range(max_dim):
-            temp += combinations(v, j)
-        ref_col = temp
-        
-        assert Multinomial(v, n_out, max_dim).n_factor == v, \
-        f'self.n_factor expected {v}, got {Multinomial(v, n_out, max_dim).n_factor}'
-        
-        assert Multinomial(v, n_out, max_dim).coef_column == ref_col,\
-        f'shape of self.coef_table expected {n_out, ref_col}, got {Multinomial(v, n_out, max_dim).coef_table.shape[0], Multinomial(v, n_out, max_dim).coef_column}'
 
 # Red test: inappropriate inputs : n_out
-def test_invalid_n_out(): # 何のテストなのかわかりやすい関数名
+def test_invalid_n_out():
     arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2]]
     n_factor = 2
     max_dim = 2
-    
+
     for v in arg:
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(ValueError) as e:
             Multinomial(n_factor, v, max_dim)
-            assert f'{v}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+        assert f'{v}' in f'{e.value}',\
+            f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+
 
 # Green test
 def test_correct_n_out(correct_input):
     n_factor = 2
     max_dim = 2
-    
-    for i, v in enumerate(correct_input):
-        assert Multinomial(n_factor, v, max_dim).n_out == v, \
-        f'self.n_out expected {v}, got {Multinomial(n_factor, v, max_dim).n_out}'
-        
-        assert Multinomial(n_factor, v, max_dim).coef_table.shape[0] == v,\
-        f'shape of self.coef_table expected {v, Multinomial(n_factor, v, max_dim).coef_column}, got {Multinomial(n_factor, v, max_dim).coef_table.shape}'
+
+    for v in correct_input:
+        res = Multinomial(n_factor, v, max_dim)
+        assert res.n_out == v, \
+            f'self.n_out expected {v}, got {res.n_out}'
+
+        assert res.coef_table.shape[0] == v,\
+            f'shape of self.coef_table expected {(v, res.coef_table.shape[1])}, got {res.coef_table.shape}'  # noqa: E501
 
 
 # Red test: inappropriate inputs : max_dim
 def test_invalid_max_dim():
-    arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2], 10] # n_factor<max_dimを追加
+    # n_factor<max_dimを追加
+    arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2], 10]
     n_factor = 2
     n_out = 2
-    
+
     for v in arg:
-        with pytest.raises(AssertionError) as e:
-            Multinomial(n_factor, n_out, arg)
-            assert f'{v}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+        try:
+            res = Multinomial(n_factor, n_out, v)
+        except ValueError as e:
+            assert f'{v}' in f'{e.args[0]}',\
+                f'NoReasons: Inform the AssertionError reasons, got {e.args[0]}'
+        except Exception as e:
+            pytest.fail(f'{type(e)}: {e.args}')
+        else:
+            pytest.fail(f'Did not Raise ValueError, got {v} -> {res}')
+
 
 # Green test
 def test_correct_max_dim():
     n_factor = 10
     n_out = 2
     arg = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    
-    for i, v in enumerate(arg):
-        assert Multinomial(n_factor, n_out, v).max_dim == arg[i], \
-        f'self.max_dim expected {arg[i]}, got {Multinomial(n_factor, n_out, v).max_dim}'
-        
-        # !!!のちのちcombination が加味されるので
-        temp = 0
-        for j in range(v):
-            temp += combinations(n_factor, j)
-        ref_col = temp
 
-        assert Multinomial(n_factor, n_out, v).coef_column == ref_col,\
-        f'shape of self.coef_table expected {n_out}, {ref_col}, got {Multinomial(n_factor, n_out, v).coef_table.shape}'
+    for i, v in enumerate(arg):
+        res = Multinomial(n_factor, n_out, v)
+        assert res.max_dim == arg[i], \
+            f'self.max_dim expected {arg[i]}, got {res.max_dim}'
+
+        # !!!のちのちcombination が加味されるので
+        factor = [f'x{i}' for i in range(n_factor)]
+        ref_col = get_comb_name(factor, v)
+
+        assert res.coef_column == ref_col,\
+            f'shape of self.coef_table expected {n_out}, {ref_col}, got {res.coef_table.shape}'
 
 
 # Red test: inappropriate inputs : exmat
 def test_invalid_exmat():
-    arg1 = [1, 0, -1, 2.0, 'a', True, [1, 2]] 
-    arg2 = [np.arange(15).reshape(3, 5), np.zeros(6).reshape(2, 3), np.random.random((1, 8))] # ex_mat.shape[1] != n_factor:2
+    arg1 = [1, 0, -1, 2.0, 'a', True, [1, 2]]
+    # ex_mat.shape[1] != n_factor:2
+    arg2 = [np.arange(15).reshape(3, 5), np.zeros((2, 3)), np.random.random((1, 8))]
     n_factor = 2
     n_out = 2
     max_dim = 2
     test = Multinomial(n_factor, n_out, max_dim)
-    
+
     for v1 in arg1:
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(ValueError) as e:
             test.simulate(v1)
-            assert f'{v1}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
-    
+            assert f'{v1}' in f'{e.value}',\
+                f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+
     for v2 in arg2:
-        with pytest.raises(AssertionError) as e:
+        with pytest.raises(ValueError) as e:
             test.simulate(v2)
-            assert f'{v2}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, the shape of input {e.value} was not equal to {n_factor}'
+            assert f'{v2}' in f'{e.value}',\
+                f'NoReasons: Inform the AssertionError reasons'
+
 
 # Green test
 def test_correct_exmat():
     n_factor = [5, 4, 3, 8]
     n_out = 2
     max_dim = 2
-    arg = [np.arange(10).reshape(2, 5), np.zeros(20).reshape(5, 4), np.ones(9).reshape(3, 3), np.random.random(8).reshape(1,8)] 
-    
-    for i, v in enumerate(arg):
-        test = Multinomial(n_factor[i], n_out, max_dim)
-        assert test.simulate(v).exmatrix == arg[i], \
-        f'ex_matrix expected {arg[i]}, got {test.simulate(v).exmatrix}'
+    args = [
+        np.arange(10).reshape(2, 5),
+        np.zeros((5, 4)),
+        np.ones(9).reshape(3, 3),
+        np.random.random(8).reshape(1, 8),
+    ]
+
+    for f, arg in zip(n_factor, args):
+        Multinomial(f, n_out, max_dim).simulate(arg)
+
 
 # Green test: output
-# datatype / shape / contents 
-
+# datatype / shape / contents
 def test_valid_resmat():
-    
+
     n_factor = [3, 4, 5, 8]
     n_out = 2
     max_dim = 2
-    ex_mat = [np.ones((3,3)), np.zeros((5,4)), np.arange(10).reshape(2, 5), np.random.random((1, 8))] 
-    ref_col = np.zeros(n_factor)
-    '''
-    for i in n_factor:
-        temp = 0
-        for j in max_dim:
-            temp += combinations(i, j)
-        ref_col[i] = temp
-    '''
-    
+    ex_mat = [
+        np.ones((3, 3)),
+        np.zeros((5, 4)),
+        np.arange(10).reshape(2, 5),
+        np.random.random((1, 8))
+    ]
+
     for i, v in enumerate(ex_mat):
         test = Multinomial(n_factor[i], n_out, max_dim)
+        try:
+            ref = test.simulate(v)
+        except Exception as ex:
+            pytest.fail(
+                f'{v.shape, test.coef_table.T.shape, test.err.shape} \n {ex.args} \n {ex.__class__}'
+            )
+
+        res = v @ test.coef_table.T
         ref = test.simulate(v)
-        res = v @ self.coef_table.T
-        
+
         # shape
         assert res.shape == ref[i].shape, \
-        f'shape of result_matrix expected {ref[i].shape}, got {res.shape}'
-        
+            f'shape of result_matrix expected {ref[i].shape}, got {res.shape}'
+
         # datatype
         assert isinstance(ref[i], type(res)), \
-        f'type of result_matrix expected {type(ref[i])}, got {type(res)}'
-        
+            f'type of result_matrix expected {type(ref[i])}, got {type(res)}'
+
         # culculation
         assert res == ref[i], \
-        f'result_matrix expected {ref[i]}, got{res}'
+            f'result_matrix expected {ref[i]}, got{res}'

--- a/tests/simulator/test_multinomial.py
+++ b/tests/simulator/test_multinomial.py
@@ -1,0 +1,196 @@
+import numpy as np
+from math import factorial
+import pytest
+
+from tagupy.simulator import Multinomial
+
+def combinations(n, r):
+    return factorial(n) // (factorial(n - r) * factorial(r))
+
+@pytest.fixture
+
+def correct_input():
+    return [1, 2, 3, 4, 5, 6, 30]
+
+
+# Red test: inappropriate inputs : n_factor
+def test_invalid_n_factor(): # 何のテストなのかわかりやすい関数名
+    arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2]]
+    n_out = 2
+    max_dim = 2
+    
+    for v in arg:
+        with pytest.raises(AssertionError) as e:
+            Multinomial(v, n_out, max_dim)
+            assert f'{v}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+
+# Green test
+def test_correct_n_factor(correct_input):
+    n_out = 2
+    max_dim = 2
+    
+    for i, v in enumerate(correct_input):
+        
+        temp = 0
+        for j in range(max_dim):
+            temp += combinations(v, j)
+        ref_col = temp
+        
+        assert Multinomial(v, n_out, max_dim).n_factor == v, \
+        f'self.n_factor expected {v}, got {Multinomial(v, n_out, max_dim).n_factor}'
+        
+        assert Multinomial(v, n_out, max_dim).coef_column == ref_col,\
+        f'shape of self.coef_table expected {n_out, ref_col}, got {Multinomial(v, n_out, max_dim).coef_table.shape[0], Multinomial(v, n_out, max_dim).coef_column}'
+
+
+
+# Red test: inappropriate inputs : n_factor
+def test_invalid_n_factor(): # 何のテストなのかわかりやすい関数名
+    arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2]]
+    n_out = 2
+    max_dim = 2
+    
+    for v in arg:
+        with pytest.raises(AssertionError) as e:
+            Multinomial(v, n_out, max_dim)
+            assert f'{v}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+
+# Green test
+def test_correct_n_factor(correct_input):
+    n_out = 2
+    max_dim = 2
+    ref_col = []
+ 
+    for i, v in enumerate(correct_input):
+        
+        temp = 0
+        for j in range(max_dim):
+            temp += combinations(v, j)
+        ref_col = temp
+        
+        assert Multinomial(v, n_out, max_dim).n_factor == v, \
+        f'self.n_factor expected {v}, got {Multinomial(v, n_out, max_dim).n_factor}'
+        
+        assert Multinomial(v, n_out, max_dim).coef_column == ref_col,\
+        f'shape of self.coef_table expected {n_out, ref_col}, got {Multinomial(v, n_out, max_dim).coef_table.shape[0], Multinomial(v, n_out, max_dim).coef_column}'
+
+# Red test: inappropriate inputs : n_out
+def test_invalid_n_out(): # 何のテストなのかわかりやすい関数名
+    arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2]]
+    n_factor = 2
+    max_dim = 2
+    
+    for v in arg:
+        with pytest.raises(AssertionError) as e:
+            Multinomial(n_factor, v, max_dim)
+            assert f'{v}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+
+# Green test
+def test_correct_n_out(correct_input):
+    n_factor = 2
+    max_dim = 2
+    
+    for i, v in enumerate(correct_input):
+        assert Multinomial(n_factor, v, max_dim).n_out == v, \
+        f'self.n_out expected {v}, got {Multinomial(n_factor, v, max_dim).n_out}'
+        
+        assert Multinomial(n_factor, v, max_dim).coef_table.shape[0] == v,\
+        f'shape of self.coef_table expected {v, Multinomial(n_factor, v, max_dim).coef_column}, got {Multinomial(n_factor, v, max_dim).coef_table.shape}'
+
+
+# Red test: inappropriate inputs : max_dim
+def test_invalid_max_dim():
+    arg = [0, -1, 2.0, np.zeros(5), 'a', True, [1, 2], 10] # n_factor<max_dimを追加
+    n_factor = 2
+    n_out = 2
+    
+    for v in arg:
+        with pytest.raises(AssertionError) as e:
+            Multinomial(n_factor, n_out, arg)
+            assert f'{v}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+
+# Green test
+def test_correct_max_dim():
+    n_factor = 10
+    n_out = 2
+    arg = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    
+    for i, v in enumerate(arg):
+        assert Multinomial(n_factor, n_out, v).max_dim == arg[i], \
+        f'self.max_dim expected {arg[i]}, got {Multinomial(n_factor, n_out, v).max_dim}'
+        
+        # !!!のちのちcombination が加味されるので
+        temp = 0
+        for j in range(v):
+            temp += combinations(n_factor, j)
+        ref_col = temp
+
+        assert Multinomial(n_factor, n_out, v).coef_column == ref_col,\
+        f'shape of self.coef_table expected {n_out}, {ref_col}, got {Multinomial(n_factor, n_out, v).coef_table.shape}'
+
+
+# Red test: inappropriate inputs : exmat
+def test_invalid_exmat():
+    arg1 = [1, 0, -1, 2.0, 'a', True, [1, 2]] 
+    arg2 = [np.arange(15).reshape(3, 5), np.zeros(6).reshape(2, 3), np.random.random((1, 8))] # ex_mat.shape[1] != n_factor:2
+    n_factor = 2
+    n_out = 2
+    max_dim = 2
+    test = Multinomial(n_factor, n_out, max_dim)
+    
+    for v1 in arg1:
+        with pytest.raises(AssertionError) as e:
+            test.simulate(v1)
+            assert f'{v1}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, got {e.value}'
+    
+    for v2 in arg2:
+        with pytest.raises(AssertionError) as e:
+            test.simulate(v2)
+            assert f'{v2}' in f'{e.value}', f'NoReasons: Inform the AssertionError reasons, the shape of input {e.value} was not equal to {n_factor}'
+
+# Green test
+def test_correct_exmat():
+    n_factor = [5, 4, 3, 8]
+    n_out = 2
+    max_dim = 2
+    arg = [np.arange(10).reshape(2, 5), np.zeros(20).reshape(5, 4), np.ones(9).reshape(3, 3), np.random.random(8).reshape(1,8)] 
+    
+    for i, v in enumerate(arg):
+        test = Multinomial(n_factor[i], n_out, max_dim)
+        assert test.simulate(v).exmatrix == arg[i], \
+        f'ex_matrix expected {arg[i]}, got {test.simulate(v).exmatrix}'
+
+# Green test: output
+# datatype / shape / contents 
+
+def test_valid_resmat():
+    
+    n_factor = [3, 4, 5, 8]
+    n_out = 2
+    max_dim = 2
+    ex_mat = [np.ones((3,3)), np.zeros((5,4)), np.arange(10).reshape(2, 5), np.random.random((1, 8))] 
+    ref_col = np.zeros(n_factor)
+    '''
+    for i in n_factor:
+        temp = 0
+        for j in max_dim:
+            temp += combinations(i, j)
+        ref_col[i] = temp
+    '''
+    
+    for i, v in enumerate(ex_mat):
+        test = Multinomial(n_factor[i], n_out, max_dim)
+        ref = test.simulate(v)
+        res = v @ self.coef_table.T
+        
+        # shape
+        assert res.shape == ref[i].shape, \
+        f'shape of result_matrix expected {ref[i].shape}, got {res.shape}'
+        
+        # datatype
+        assert isinstance(ref[i], type(res)), \
+        f'type of result_matrix expected {type(ref[i])}, got {type(res)}'
+        
+        # culculation
+        assert res == ref[i], \
+        f'result_matrix expected {ref[i]}, got{res}'


### PR DESCRIPTION
* TaguPy version:
* Python version:
* Operating System:

### What

- multinomial simulatorの追加
- multinomial simulatorのtest codeの追加
- 多項式を用いてex_matrixの仮想的な結果を出力するsimulator


### Why

Describe the intention.
